### PR TITLE
Double based expr evaluation (disablable)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ CFLAGS = -Wall -Werror -pedantic -O2 -DNDEBUG
 LFLAGS = -s -fno-exceptions -lm
 endif
 
+ifeq ($(MATH),int)
+CFLAGS := $(CFLAGS) -DFIZ_INTEGER_EXPR
+endif
+
 all: fiz docs
 
 debug:

--- a/fiz.c
+++ b/fiz.c
@@ -152,7 +152,7 @@ static enum FI_CODE parse_quote(Fiz *F, FizParser *FI, char term) {
             const char *p, *val;
             char *name;
             p = ++FI->txt;
-            while(isalnum(*FI->txt)) FI->txt++;
+            while(isalnum((int)*FI->txt)) FI->txt++;
             if(FI->txt == p) {
                 fiz_set_return(F, "Identifier expected after $");
                 return FI_ERR;
@@ -258,7 +258,7 @@ static enum FI_CODE get_word(Fiz *F, FizParser *FI) {
 
 restart:
     /* Remove whitespace */
-    while(isspace(FI->txt[0])) {
+    while(isspace((int)FI->txt[0])) {
         if(FI->txt[0] == '\n') {
             FI->txt++;
             return FI_EOS;
@@ -310,7 +310,7 @@ restart:
                 const char *p, *val;
                 char *name;
                 p = ++FI->txt;
-                while(isalnum(*FI->txt)) FI->txt++;
+                while(isalnum((int)*FI->txt)) FI->txt++;
                 if(FI->txt == p) {
                     fiz_set_return(F, "Identifier expected after $");
                     return FI_ERR;
@@ -335,7 +335,7 @@ restart:
 
             add_char(FI, c);
             FI->txt++;
-        } while(FI->txt[0] && !isspace(FI->txt[0]));
+        } while(FI->txt[0] && !isspace((int)FI->txt[0]));
         return FI_WORD;
     }
     return FI_ERR; /* keeps some compilers happy */
@@ -456,10 +456,10 @@ Fiz_Code fiz_exec(Fiz *F, const char *str) {
             int i = 1, brk = 0;
             add_callframe(F);
             for(n=pars; !brk && *n; n++, i++) {
-                while(n[0] && isspace(n[0])) n++;
+                while(n[0] && isspace((int)n[0])) n++;
                 if(!n[0]) break;
                 c = n;
-                while(n[0] && !isspace(n[0])) n++;
+                while(n[0] && !isspace((int)n[0])) n++;
                 if(!n[0]) brk = 1;
                 n[0] = '\0';
                 if(i < argc)

--- a/fiz.h
+++ b/fiz.h
@@ -109,10 +109,17 @@ const char *fiz_get_var(Fiz *F, const char *name);
  */
 char *fiz_readfile(const char *filename);
 
+#ifdef FIZ_INTEGER_EXPR
 /*@ int expr(const char *str, const char **err);
  *# The expression evaluator used with the {{expr}} command.
  *# See {{expr.c}} for details */
 int expr(const char *str, const char **err);
+#else
+/*@ double expr(const char *str, const char **err);
+ *# The expression evaluator used with the {{expr}} command.
+ *# See {{expr.c}} for details */
+double expr(const char *str, const char **err);
+#endif
 
 /*@ char *fiz_substitute(Fiz *F, const char *s);
  *# Performs $variable substitution on a string. It also evaluates


### PR DESCRIPTION
Adds the double based expr evaluation promissed in #1.

If someone wants to use the old integer based math, it's still available behind a define symbol.
Details and limitations listed in expr.c