### PR TITLE
Added `fiz_get_last_statement` function

### DIFF
--- a/auxfuns.c
+++ b/auxfuns.c
@@ -195,3 +195,19 @@ void fiz_add_aux(Fiz *F) {
     fiz_add_func(F, "dict", aux_dict, NULL);
     fiz_add_func(F, "include", aux_include, NULL);
 }
+
+char *fiz_get_last_statement(Fiz *F) {
+    if (!F->last_statement_begin || !F->last_statement_end)
+        return strdup("(none)");
+    int length = F->last_statement_end - F->last_statement_begin;
+    char* last_statement = strndup(F->last_statement_begin, length);
+    // Strip newline and whitespace at end of statement
+    for (int i = length - 1; i >= 0; i--) {
+        char ch = last_statement[i];
+        if (ch == ' ' || ch == '\t' || ch == '\n')
+            last_statement[i] = '\0';
+        else 
+            break;
+    }
+    return last_statement;
+}

--- a/fiz.h
+++ b/fiz.h
@@ -23,6 +23,8 @@ typedef struct fiz {
 	struct hash_tbl *dicts;
 	struct fiz_callframe *callframe;
 	char *return_val;
+	char const* last_statement_begin;
+	char const* last_statement_end;
 } Fiz;
 
 /*@ typedef enum fiz_code {FIZ_OK, FIZ_ERROR, FIZ_RETURN, FIZ_CONTINUE, FIZ_BREAK} Fiz_Code;
@@ -157,3 +159,10 @@ void fiz_dict_delete(Fiz *F, const char *dict, const char *key);
  *#
  */
 const char *fiz_dict_next(Fiz *F, const char *dict, const char *key);
+
+/*@ char *fiz_get_last_statement(Fiz *F);
+ *# Returns last statement that was executed by the engine,
+ *# good for diagnostics or error reporting
+ *# The returned string is dynamic, so it must be {{free()}}'ed afterwards
+ */
+char *fiz_get_last_statement(Fiz *F);

--- a/shell.c
+++ b/shell.c
@@ -43,7 +43,11 @@ int main(int argc, char *argv[]) {
         }
         c = fiz_exec(F, script);
         if(c == FIZ_ERROR)
-            fprintf(stderr, "error: %s\n", fiz_get_return(F));
+        {
+            char* last_statement = fiz_get_last_statement(F);
+            fprintf(stderr, "error: %s in \"%s\"\n", fiz_get_return(F), last_statement);
+            free(last_statement);
+        }
         free(script);
     }
 


### PR DESCRIPTION
Another useful thing I had lying in my fork - a function to retrieve the last statement that was called by the interpreter. Good for debugging script errors.