### PR TITLE
Floating point math fix and a few smaller fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,15 @@ I took some inspiration (like how the callframes are handled and several of the
 API functions) from Salvatore Sanfilippo's Picol Tcl interpreter, which can be 
 found at http://antirez.com/page/picol. This is, however, a new implementation.
 
+
+## Compile time flags
+
+To make Fiz usable in different configurations, some compile time flags have
+been added. Define these in your environment for the desired effect.
+
+* `FIZ_DISABLE_INCLUDE_FILES` - disables `fiz_readfile` function, `include`
+  command and the interactive shell. Provided for embedding into other 
+  applications
+
+* `FIZ_INTEGER_EXPR` - changes the floating point expression evaluation
+  to use integers

--- a/auxfuns.c
+++ b/auxfuns.c
@@ -13,6 +13,7 @@
 
 #include "fiz.h"
 
+#ifndef FIZ_DISABLE_INCLUDE_FILES
 char *fiz_readfile(const char *filename) {
     FILE *f;
     long len,r;
@@ -38,6 +39,7 @@ char *fiz_readfile(const char *filename) {
     str[len] = '\0';
     return str;
 }
+#endif
 
 static Fiz_Code aux_puts(Fiz  *F, int argc, char **argv, void *data) {
     if(argc != 2)
@@ -170,6 +172,7 @@ static Fiz_Code aux_dict(Fiz *F, int argc, char **argv, void *data) {
     return FIZ_OK;
 }
 
+#ifndef FIZ_DISABLE_INCLUDE_FILES
 static Fiz_Code aux_include(Fiz *F, int argc, char **argv, void *data) {
     Fiz_Code rc;
     char *str;
@@ -184,6 +187,7 @@ static Fiz_Code aux_include(Fiz *F, int argc, char **argv, void *data) {
     free(str);
     return rc;
 }
+#endif
 
 void fiz_add_aux(Fiz *F) {
     fiz_add_func(F, "puts", aux_puts, NULL);
@@ -193,5 +197,7 @@ void fiz_add_aux(Fiz *F) {
     fiz_add_func(F, "incr", aux_incr, NULL);
     fiz_add_func(F, "decr", aux_incr, NULL);
     fiz_add_func(F, "dict", aux_dict, NULL);
+#ifndef FIZ_DISABLE_INCLUDE_FILES
     fiz_add_func(F, "include", aux_include, NULL);
+#endif
 }

--- a/fiz.c
+++ b/fiz.c
@@ -70,7 +70,7 @@ static int init_parser(FizParser *FI, const char *txt) {
     FI->word = malloc(FI->a_size);
     FI->w_size = 0;
     FI->txt = txt;
-    return 1;
+    return (FI->word) ? 1 : 0;
 }
 
 static void destroy_parser(FizParser *FI) {
@@ -368,6 +368,8 @@ static void add_bifs(Fiz *F);
 
 Fiz *fiz_create() {
     Fiz *F = malloc(sizeof *F);
+    if(!F) 
+        return NULL;
     F->callframe = NULL;
     add_callframe(F);
     F->commands = ht_create(0);
@@ -621,6 +623,12 @@ Fiz_Code fiz_argc_error(Fiz *F, const char *cmd, int exp) {
     return FIZ_ERROR;
 }
 
+Fiz_Code fiz_oom_error(Fiz *F) {
+    // empty string, better not allocate anything large
+    fiz_set_return(F, "");
+    return FIZ_OOM;
+}
+
 static Fiz_Code bif_set(Fiz *F, int argc, char **argv, void *data) {
     if(argc != 3)
         return fiz_argc_error(F, argv[0], 3);
@@ -680,7 +688,7 @@ static Fiz_Code bif_while(Fiz *F, int argc, char **argv, void *data) {
         if(!atoi(fiz_get_return(F))) break;
         fc = fiz_exec(F, argv[2]);
         if(fc == FIZ_BREAK) break;
-        else if(fc == FIZ_ERROR) return FIZ_ERROR;
+        else if(fc == FIZ_ERROR || fc == FIZ_OOM) return fc;
     }
     return FIZ_OK;
 }

--- a/fiz.h
+++ b/fiz.h
@@ -25,10 +25,10 @@ typedef struct fiz {
 	char *return_val;
 } Fiz;
 
-/*@ typedef enum fiz_code {FIZ_OK, FIZ_ERROR, FIZ_RETURN, FIZ_CONTINUE, FIZ_BREAK} Fiz_Code;
+/*@ typedef enum fiz_code {FIZ_OK, FIZ_ERROR, FIZ_OOM, FIZ_RETURN, FIZ_CONTINUE, FIZ_BREAK} Fiz_Code;
  *# Values that can be returned by functions implementing the various commands.
  */
-typedef enum fiz_code {FIZ_OK, FIZ_ERROR, FIZ_RETURN, FIZ_CONTINUE, FIZ_BREAK} Fiz_Code;
+typedef enum fiz_code {FIZ_OK, FIZ_ERROR, FIZ_OOM, FIZ_RETURN, FIZ_CONTINUE, FIZ_BREAK} Fiz_Code;
 
 /*@ typedef Fiz_Code (*fiz_func)(Fiz *f, int argc, char **argv, void *data);
  *# Prototype for C-functions that can be added to the interpreter.
@@ -136,6 +136,11 @@ char *fiz_substitute(Fiz *F, const char *s);
  *# See any of the built-in functions for its usage.
  */
 Fiz_Code fiz_argc_error(Fiz *F, const char *cmd, int exp);
+
+/*@ Fiz_Code fiz_oom_error(Fiz *F);
+ *# Helper function to report out of memory errors
+ */
+Fiz_Code fiz_oom_error(Fiz *F);
 
 /*2 Functions for Manipulating Dictionaries
  */

--- a/shell.c
+++ b/shell.c
@@ -30,6 +30,8 @@ int main(int argc, char *argv[]) {
                 printf("ok: %s\n", fiz_get_return(F));
             } else if(c == FIZ_ERROR) {
                 fprintf(stderr, "error: %s\n", fiz_get_return(F));
+            } else if(c == FIZ_OOM) {
+                fprintf(stderr, "out of memory error\n");
             }
             printf("%s", PROMPT);
         }
@@ -44,6 +46,8 @@ int main(int argc, char *argv[]) {
         c = fiz_exec(F, script);
         if(c == FIZ_ERROR)
             fprintf(stderr, "error: %s\n", fiz_get_return(F));
+        if(c == FIZ_OOM)
+            fprintf(stderr, "out of memory error\n");
         free(script);
     }
 

--- a/shell.c
+++ b/shell.c
@@ -4,6 +4,7 @@
  * This is free and unencumbered software released into the public domain.
  * http://unlicense.org/
  */
+#ifndef FIZ_DISABLE_INCLUDE_FILES
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -50,3 +51,4 @@ int main(int argc, char *argv[]) {
     fiz_destroy(F);
     return 0;
 }
+#endif


### PR DESCRIPTION
Fixed a nasty bug (that I introduced earlier, sorry!) where floating point value string normalization caused trailing zeroes to be removed also from the integral part (ie. 123400.000 was changed to 1234 but should be to 123400)

Added a compile flag to disable reading files and compiling `shell.c` - it allows for using Fiz as an embedded interpreter, not just a stand alone program.

Added some out of memory detection. Might add some more in time.

@Wernsey, if you prefer smaller pull requests, tell me and I might divide into features in the future.